### PR TITLE
Simplifications: fixed "^ is a binary operator"

### DIFF
--- a/miasm/expression/simplifications_common.py
+++ b/miasm/expression/simplifications_common.py
@@ -1147,8 +1147,8 @@ def simp_cmp_bijective_op(expr_simp, expr):
     if not args_b:
         return ExprOp(TOK_EQUAL, ExprOp(op, *args_a), ExprInt(0, args_a[0].size))
     
-    arg_a = ExprOp(op, *args_a)
-    arg_b = ExprOp(op, *args_b)
+    arg_a = ExprOp(op, *args_a) if len(args_a) > 1 else args_a[0]
+    arg_b = ExprOp(op, *args_b) if len(args_b) > 1 else args_b[0]
     return ExprOp(TOK_EQUAL, arg_a, arg_b)
 
 


### PR DESCRIPTION
In Miasm Python, using ^ and + as unary operators is allowed. In Miasm Rust, it's not.

This patch fixes two tests by teaching Python what to do when a unary operator is necessary:
`a op b == a op c  <=>  b == c`
when 'op' is ^ or +